### PR TITLE
Add withCredentials option

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,6 +22,8 @@ module.exports = function(config) {
               if (request.url === '/base/data' && request.method === 'POST') {
                 var body = '';
 
+                response.setHeader('Access-Control-Allow-Origin', '*');
+
                 request.on('data', function(data) {
                   body += data;
                 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,12 @@ exports.base64 = base64;
 exports.type = cors ? 'xhr' : 'jsonp';
 
 /**
+ * Expose `withCredentials`.
+ */
+
+exports.withCredentials = false;
+
+/**
  * Send the given `obj` to `url` with `fn(err, req)`.
  *
  * @param {String} url
@@ -61,13 +67,14 @@ function json(url, obj, headers, fn) {
   var req = new XMLHttpRequest;
   req.onerror = fn;
   req.onreadystatechange = done;
+  req.withCredentials = cors && !!exports.withCredentials;
   req.open('POST', url, true);
 
-  // TODO: Remove this eslint disable
   // eslint-disable-next-line guard-for-in
   for (var k in headers) {
     req.setRequestHeader(k, headers[k]);
   }
+
   req.send(JSON.stringify(obj));
 
   function done() {


### PR DESCRIPTION
Adds a `withCredentials` option on `exports`, defaults to false.

```js
var send = require('send-json');

send.withCredentials = true;
send(....);
```

Added it to exports to keep the function signature from being awkward with `send(url, data, headers, options, fn)`, but that may make more sense. Thoughts?

