### PR TITLE
json: Support timeout

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,22 +46,28 @@ exports.base64 = base64;
 exports.type = cors ? 'xhr' : 'jsonp';
 
 /**
- * Send the given `obj` to `url` with `fn(err, req)`.
+ * Send the given `obj` to `url` with `fn(err, req)`. A timeout of zero or
+ * undefined indicates no timeout.
  *
  * @param {String} url
  * @param {Object} obj
  * @param {Object} headers
+ * @param {long} timeout
  * @param {Function} fn
  * @api private
  */
 
-function json(url, obj, headers, fn) {
-  if (arguments.length === 3) fn = headers, headers = {};
-
+function json(url, obj, headers, timeout, fn) {
   var req = new XMLHttpRequest;
   req.onerror = fn;
   req.onreadystatechange = done;
+
   req.open('POST', url, true);
+
+  if (timeout) {
+    req.timeout = timeout;
+    req.ontimeout = fn;
+  }
 
   // TODO: Remove this eslint disable
   // eslint-disable-next-line guard-for-in

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,7 +17,19 @@ describe('send-json', function() {
       if (send.type !== 'xhr') return done();
 
       var headers = { 'Content-Type': 'application/json' };
-      send.json(url, [1, 2, 3], headers, function(err, req) {
+      send.json(url, [1, 2, 3], headers, 0, function(err, req) {
+        if (err) return done(new Error(err.message));
+        var res = json.parse(req.responseText);
+        assert(res === true);
+        done();
+      });
+    });
+
+    it('should work with timeout', function(done) {
+      if (send.type !== 'xhr') return done();
+
+      var headers = { 'Content-Type': 'application/json' };
+      send.json(url, [1, 2, 3], headers, 10 * 1000, function(err, req) {
         if (err) return done(new Error(err.message));
         var res = json.parse(req.responseText);
         assert(res === true);


### PR DESCRIPTION
It's a good idea to set a timeout for HTTP requests. This is particularly helpful when we use this package via analytics.js and localstorage-retry. Setting a timeout will help avoid resource contention when the network is flaky.

The timeout must be passed as an option. A timeout of zero indicates no timeout. This is a breaking API change, so I'll be releasing this as a new major version.

Since this is a breaking change, I removed support for optional arguments to make the code easier to read. At least in a.js, we use all the options anyway.