### PR TITLE
Support timeout for base64 function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,9 +92,7 @@ function json(url, obj, headers, timeout, fn) {
  * @api private
  */
 
-function base64(url, obj, _, fn) {
-  if (arguments.length === 3) fn = _;
-
+function base64(url, obj, headers, timeout, fn) {
   var prefix = exports.prefix;
   var data = encode(obj);
   url += '?' + prefix + '=' + data;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -56,5 +56,23 @@ describe('send-json', function() {
         done();
       });
     });
+
+    it('should work with timeout', function(done) {
+      if (send.type !== 'jsonp') return done();
+
+      var url = protocol + '//www.reddit.com/r/pics.json';
+      send.callback = 'jsonp';
+      send.base64(url, [1, 2, 3], {}, 10 * 1000, function(err, req) {
+        if (err) return done(new Error(err.message));
+        var data = req.url.split('data=')[1];
+        data = decodeURIComponent(data);
+        data = json.parse(decode(data));
+        assert(data[0] === 1);
+        assert(data[1] === 2);
+        assert(data[2] === 3);
+        assert(req.body.kind === 'Listing');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
When sending the PR for https://github.com/segmentio/send-json/pull/2, I didn't fully understand how this was being used in a.js-integration-segmentio.

Turns out that this module changes it's default export based on whether the browser supports CORS or not (https://github.com/segmentio/send-json/blob/master/lib/index.js#L16).

This means, under certain cases,  a.js-integration-segmentio may call the base64 version with the timeout. This would have thrown an error because the function callback would have been undefined.