### PR TITLE
use sendBeacon when available to support before/unload event sending

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,17 @@ exports.type = cors ? 'xhr' : 'jsonp';
  */
 
 function json(url, obj, headers, timeout, fn) {
+  headers = headers || {};
+  if (navigator.sendBeacon
+      && Object.keys
+      && Object.keys(headers).length <= 1
+      && (!headers['Content-Type'] || headers['Content-Type'].indexOf('text/plain') > -1)) {
+    var res = navigator.sendBeacon(url, JSON.stringify(obj));
+    if (fn) {
+      fn(res ? null : { error: 'Failed to send' }, null);
+    }
+    return;
+  }
   var req = new XMLHttpRequest;
   req.onerror = fn;
   req.onreadystatechange = done;


### PR DESCRIPTION
https://github.com/segment-integrations/analytics.js-integration-segmentio.git
Depends on this library to send the json requests to track page/event tracking.

However, during beforeunload or unload events, many browsers (esp. Safari) do not send the tracking request.  However the [sendBeacon](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) call reliably does and integration-segmentio does not seem to send anything more sophisticated than what's possible with sendBeacon.

This PR is conservative and only uses it when headers are nothing beyond a standard cors xhr request.  If any additional headers are sent, then it fallsback to a regular xhr request.