### PR TITLE
Don't stringify buffers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,15 +49,16 @@ exports.type = cors ? 'xhr' : 'jsonp';
  * Check if the given `obj` is a raw buffer
  * 
  * @param {*} obj the object to check
- * @returns {boolean} `true` if `obj` is an `ArrayBufferView` or an `ArrayBuffer`, `false` otherwise
+ * @return {boolean} `obj` is an `ArrayBufferView` or an `ArrayBuffer`
  * @api private
  */
 function isBuffer(obj) {
-  if(!obj || typeof ArrayBuffer === 'undefined') {
-    return false
+  /* global ArrayBuffer */
+  if (!obj || typeof ArrayBuffer === 'undefined') {
+    return false;
   }
 
-  return obj instanceof ArrayBuffer || obj.buffer instanceof ArrayBuffer
+  return obj instanceof ArrayBuffer || obj.buffer instanceof ArrayBuffer;
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,21 @@ exports.base64 = base64;
 exports.type = cors ? 'xhr' : 'jsonp';
 
 /**
+ * Check if the given `obj` is a raw buffer
+ * 
+ * @param {*} obj the object to check
+ * @returns {boolean} `true` if `obj` is an `ArrayBufferView` or an `ArrayBuffer`, `false` otherwise
+ * @api private
+ */
+function isBuffer(obj) {
+  if(!obj || typeof ArrayBuffer === 'undefined') {
+    return false
+  }
+
+  return obj instanceof ArrayBuffer || obj.buffer instanceof ArrayBuffer
+}
+
+/**
  * Send the given `obj` to `url` with `fn(err, req)`. A timeout of zero or
  * undefined indicates no timeout.
  *
@@ -74,7 +89,12 @@ function json(url, obj, headers, timeout, fn) {
   for (var k in headers) {
     req.setRequestHeader(k, headers[k]);
   }
-  req.send(JSON.stringify(obj));
+
+  req.send(
+    isBuffer(obj)
+      ? obj
+      : JSON.stringify(obj)
+  );
 
   function done() {
     if (req.readyState === 4) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mocha": "^2.2.5",
     "phantomjs-prebuilt": "^2.1.7",
     "proclaim": "^3.4.1",
+    "sinon": "^6.0.1",
     "watchify": "^3.7.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('proclaim');
+var sinon = require('sinon');
 var decode = require('base64-decode');
 var json = require('json3');
 var send = require('../lib');
@@ -35,6 +36,23 @@ describe('send-json', function() {
         assert(res === true);
         done();
       });
+    });
+
+    it('should not stringify buffers', function(done) {
+      /* global ArrayBuffer, Uint8Array */
+      if (typeof ArrayBuffer === 'undefined') return done();
+
+      var xhr = sinon.useFakeXMLHttpRequest();
+      var data = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+
+      xhr.onCreate = function(req) {
+        req.send = function(payload) {
+          assert(payload === data);
+          done();
+        };
+      };
+
+      send.json(url, data, {});
     });
   });
 


### PR DESCRIPTION
Ref: https://segment.atlassian.net/browse/LIB-399

I'm implementing the gzip part on `analytics.js-core` so this is needed to send raw compressed data.
We could also directly implement gzip here, happy to hear some thoughts!